### PR TITLE
Stabilize softmax operation with learnable modality weights in `MULTIVI`

### DIFF
--- a/scvi/module/_utils.py
+++ b/scvi/module/_utils.py
@@ -41,3 +41,17 @@ def enumerate_discrete(x, y_dim):
 
     batch_size = x.size(0)
     return torch.cat([batch(batch_size, i) for i in range(y_dim)])
+
+
+def masked_softmax(weights, mask, dim=-1, eps=1e-30):
+    """
+    Computes a softmax of ``weights`` along ``dim`` where ``mask is True``.
+
+    Adds a small ``eps`` term in the numerator and denominator to avoid zero division.
+    Taken from: https://discuss.pytorch.org/t/apply-mask-softmax/14212/15.
+    Pytorch issue tracked at: https://github.com/pytorch/pytorch/issues/55056.
+    """
+    weight_exps = torch.exp(weights)
+    masked_exps = weight_exps.masked_fill(mask == 0, eps)
+    masked_sums = masked_exps.sum(dim, keepdim=True) + eps
+    return masked_exps / masked_sums


### PR DESCRIPTION
This PR addresses an issue where with `modality_weights=universal` or `modality_weights=cell`, training would fail after a single gradient step due to nans.

I identified this to be caused by the masked softmax operation where the `masks==0` was converted to `float("-inf")` such that those elements would become zero after softmaxing.

This issue is tracked in the PyTorch repo here https://github.com/pytorch/pytorch/issues/55056.

I implemented a "safe" version of the masked softmax sugessted here https://github.com/pytorch/pytorch/issues/41508#issuecomment-775030992.

However, there is an additional unknown component to this issue because, I still got nans in the first gradient step when the masked elements were entirely zeroed out, rather than replaced with a small epsilon value (e.g. 1e-30). Some more investigation is necessary to address this, but this PR solves the larger issue within a trivial error bound.